### PR TITLE
Darwin root

### DIFF
--- a/detect_locale_darwin.go
+++ b/detect_locale_darwin.go
@@ -1,5 +1,9 @@
 package go_locale
 
 func DetectLocale() (string, error) {
-    return getCommandOutput("defaults", "read", "-g", "AppleLocale")
+	return getCommandOutput(
+		"defaults",
+		"read",
+		"/Library/Preferences/.GlobalPreferences",
+		"AppleLocale")
 }

--- a/locale_test.go
+++ b/locale_test.go
@@ -1,0 +1,11 @@
+package go_locale
+
+import "testing"
+
+func TestLocale(t *testing.T) {
+	if lc, err := DetectLocale(); err != nil {
+		t.Fatal(err)
+	} else {
+		t.Logf("detected locale: %q", lc)
+	}
+}


### PR DESCRIPTION
Fixes `DetecLocale` doesn't work with macOS when running as root.
